### PR TITLE
src/bsdconv.h: include <stdint.h> for uint32_t

### DIFF
--- a/src/bsdconv.h
+++ b/src/bsdconv.h
@@ -17,6 +17,7 @@
 #ifndef BSDCONV_H
 #define BSDCONV_H
 
+#include <stdint.h>
 #include <unistd.h>
 #include <stdlib.h>
 #ifdef WIN32


### PR DESCRIPTION
otherwise it failed on my mac, gcc version:

> cc -v
> Using built-in specs.
> Target: i686-apple-darwin10
> Configured with: /var/tmp/llvmgcc42/llvmgcc42-2335.9~9/src/configure
> --disable-checking --enable-werror --prefix=/Developer/usr/llvm-gcc-4.2
> --mandir=/share/man --enable-languages=c,objc,c++,obj-c++
> --program-prefix=llvm- --program-transform-name=/^[cg][^.-]*$/s/$/-4.2/
> --with-slibdir=/usr/lib --build=i686-apple-darwin10
> --enable-llvm=/var/tmp/llvmgcc42/llvmgcc42-2335.9~9/dst-llvmCore/Developer/usr/local
> --program-prefix=i686-apple-darwin10- --host=x86_64-apple-darwin10
> --target=i686-apple-darwin10
> --with-gxx-include-dir=/usr/include/c++/4.2.1
> Thread model: posix
> gcc version 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2335.9)
