### PR TITLE
Makefile: link -lbsdconv for codecs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ codecs_basic_table: builddir bsdconv_mktable
 
 codecs_basic_callback: builddir libbsdconv
 	for item in ${TODO_CODECS_BASIC_CALLBACK} ; do \
-		$(CC) ${CFLAGS} -fPIC -shared -o ./build/share/bsdconv/$${item}.so codecs/$${item}.c ; \
+		$(CC) ${CFLAGS} -L./build/lib/ -lbsdconv -fPIC -shared -o ./build/share/bsdconv/$${item}.so codecs/$${item}.c ; \
 	done
 
 codecs_extra_table: builddir bsdconv_mktable
@@ -194,7 +194,7 @@ codecs_extra_table: builddir bsdconv_mktable
 
 codecs_extra_callback: builddir libbsdconv
 	for item in ${TODO_CODECS_EXTRA_CALLBACK} ; do \
-		$(CC) ${CFLAGS} -fPIC -shared -o ./build/share/bsdconv/$${item}.so codecs/$${item}.c ; \
+		$(CC) ${CFLAGS} -L./build/lib/ -lbsdconv -fPIC -shared -o ./build/share/bsdconv/$${item}.so codecs/$${item}.c ; \
 	done
 
 codecs: codecs_basic codecs_extra


### PR DESCRIPTION
Otherwise I would have linking errors.
Not sure if this is only needed for mac though.
Please see [src/bsdconv.h: include <stdint.h> for uint32_t ](https://github.com/godfat/bsdconv/commit/61177da64430d18ff53beff9e79ff16ba7300c01) for my gcc version.
